### PR TITLE
Force validation  (#809)

### DIFF
--- a/application/config/rest.php
+++ b/application/config/rest.php
@@ -138,6 +138,7 @@ $config['auth_source'] = 'ldap';
 |
 */
 $config['allow_auth_and_keys'] = TRUE;
+$config['strict_api_and_auth'] = TRUE; // force the use of both api and auth before a valid api request is made
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
* Update rest.php

* Update REST_Controller.php

Update to force the use of both the api key and the basic authentication when the config value is set in rest.php
This resolves the issue of the basic auth always being valid on every request.